### PR TITLE
Dev -> Master v1.3.0

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -52,8 +52,6 @@ jobs:
         mkdir artifacts
         cp ./build/ScriptableMC-Engine-JS.jar ./artifacts/
         cp ./build/ScriptableMC-Engine-JS-Bundled.jar ./artifacts/
-#        cp ./build/ScriptableMC-Engine-PY.jar ./artifacts/
-#        cp ./build/ScriptableMC-Engine-PY-Bundled.jar ./artifacts/
         cp ./ScriptableMC-Tools-TS/lib/ScriptableMC-TypeScript-Lib.zip ./artifacts/
         cp ./ScriptableMC-Tools-TS/lib/ScriptableMC-JavaScript-Lib.zip ./artifacts/
         cp ./ScriptableMC-Tools-TS/lib-smc/Lib-SMC.zip ./artifacts/

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -52,8 +52,8 @@ jobs:
         mkdir artifacts
         cp ./build/ScriptableMC-Engine-JS.jar ./artifacts/
         cp ./build/ScriptableMC-Engine-JS-Bundled.jar ./artifacts/
-        cp ./build/ScriptableMC-Engine-PY.jar ./artifacts/
-        cp ./build/ScriptableMC-Engine-PY-Bundled.jar ./artifacts/
+#        cp ./build/ScriptableMC-Engine-PY.jar ./artifacts/
+#        cp ./build/ScriptableMC-Engine-PY-Bundled.jar ./artifacts/
         cp ./ScriptableMC-Tools-TS/lib/ScriptableMC-TypeScript-Lib.zip ./artifacts/
         cp ./ScriptableMC-Tools-TS/lib/ScriptableMC-JavaScript-Lib.zip ./artifacts/
         cp ./ScriptableMC-Tools-TS/lib-smc/Lib-SMC.zip ./artifacts/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,24 +50,24 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: 'ScriptableMC-Engine-JS/build/libs/ScriptableMC-Engine-JS.jar'
-    - name: Upload Python Engine Plugin Jar
-      uses: skx/github-action-publish-binaries@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        args: 'ScriptableMC-Engine-PY/build/libs/ScriptableMC-Engine-PY.jar'
+#    - name: Upload Python Engine Plugin Jar
+#      uses: skx/github-action-publish-binaries@master
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        args: 'ScriptableMC-Engine-PY/build/libs/ScriptableMC-Engine-PY.jar'
     - name: Upload Bundled JavaScript Engine Plugin Jar
       uses: skx/github-action-publish-binaries@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: 'ScriptableMC-Engine-JS/Bundled/build/libs/ScriptableMC-Engine-JS-Bundled.jar'
-    - name: Upload Bundled Python Engine Plugin Jar
-      uses: skx/github-action-publish-binaries@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        args: 'ScriptableMC-Engine-PY/Bundled/build/libs/ScriptableMC-Engine-PY-Bundled.jar'
+#    - name: Upload Bundled Python Engine Plugin Jar
+#      uses: skx/github-action-publish-binaries@master
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        args: 'ScriptableMC-Engine-PY/Bundled/build/libs/ScriptableMC-Engine-PY-Bundled.jar'
     - name: Upload TypeScript Libraries
       uses: skx/github-action-publish-binaries@master
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,24 +50,12 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: 'ScriptableMC-Engine-JS/build/libs/ScriptableMC-Engine-JS.jar'
-#    - name: Upload Python Engine Plugin Jar
-#      uses: skx/github-action-publish-binaries@master
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        args: 'ScriptableMC-Engine-PY/build/libs/ScriptableMC-Engine-PY.jar'
     - name: Upload Bundled JavaScript Engine Plugin Jar
       uses: skx/github-action-publish-binaries@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         args: 'ScriptableMC-Engine-JS/Bundled/build/libs/ScriptableMC-Engine-JS-Bundled.jar'
-#    - name: Upload Bundled Python Engine Plugin Jar
-#      uses: skx/github-action-publish-binaries@master
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        args: 'ScriptableMC-Engine-PY/Bundled/build/libs/ScriptableMC-Engine-PY-Bundled.jar'
     - name: Upload TypeScript Libraries
       uses: skx/github-action-publish-binaries@master
       env:

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -61,5 +61,10 @@
       <option name="name" value="JitPack" />
       <option name="url" value="https://jitpack.io" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="codemc-repo" />
+      <option name="name" value="codemc-repo" />
+      <option name="url" value="https://repo.codemc.org/repository/maven-public/" />
+    </remote-repository>
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![License](https://img.shields.io/github/license/astorks/ScriptableMC-Engine?style=for-the-badge)
 
 Run JavaScript/TypeScript plugins for Minecraft 1.15 using the GraalJS script engine.<br />
-Supported Minecraft Versions: Bukkit/Spigot/Paper 1.12, 1.13, 1.14, **1.15**<br />
+Supported Minecraft Versions: Bukkit/Spigot/Paper 1.13, 1.14, 1.15, **1.16**<br />
 Untested but should work: 1.8+
 
 **This plugin is in a preview state, there may be breaking changes, missing features, and possibly a few bugs.**<br >

--- a/README.md
+++ b/README.md
@@ -69,5 +69,6 @@ https://github.com/MinusKube/SmartInvs - Inventory helper library<br />
 https://github.com/lucko/helper - MinecraftVersions helper library<br />
 https://github.com/jkcclemens/khttp - HTTP helper library<br />
 https://github.com/aikar/commands - Built-in commands and auto-completion<br />
+https://github.com/tr7zw/Item-NBT-API - NBT helper library<br />
 https://github.com/apache/commons-io - FileUtils helper library<br />
 https://github.com/graalvm/graaljs - JavaScript engine

--- a/ScriptableMC-Engine-Core/build.gradle.kts
+++ b/ScriptableMC-Engine-Core/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("commons-io:commons-io:2.6")
+    implementation("de.tr7zw:item-nbt-api:2.2.0")
 
     testImplementation("junit", "junit", "4.12")
 }

--- a/ScriptableMC-Engine-Core/build.gradle.kts
+++ b/ScriptableMC-Engine-Core/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     compileOnly("org.graalvm.truffle:truffle-api:20.1.0")
 
     implementation("com.github.jkcclemens:khttp:-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.16.1-R0.1-SNAPSHOT")
     implementation("co.aikar:acf-paper:0.5.0-SNAPSHOT")
     implementation("fr.minuskube.inv:smart-invs:1.2.7")
     compileOnly("me.clip:placeholderapi:2.10.4")

--- a/ScriptableMC-Engine-Core/build.gradle.kts
+++ b/ScriptableMC-Engine-Core/build.gradle.kts
@@ -18,8 +18,8 @@ idea {
 
 dependencies {
     // GraalVM SDK & GraalJS Engine
-    compileOnly("org.graalvm.sdk:graal-sdk:20.0.0")
-    compileOnly("org.graalvm.truffle:truffle-api:20.0.0")
+    compileOnly("org.graalvm.sdk:graal-sdk:20.1.0")
+    compileOnly("org.graalvm.truffle:truffle-api:20.1.0")
 
     implementation("com.github.jkcclemens:khttp:-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT")

--- a/ScriptableMC-Engine-Core/src/main/kotlin/com/pixlfox/scriptablemc/ScriptEngineGlobalCommands.kt
+++ b/ScriptableMC-Engine-Core/src/main/kotlin/com/pixlfox/scriptablemc/ScriptEngineGlobalCommands.kt
@@ -30,13 +30,13 @@ class ScriptEngineGlobalCommands(private val basePlugin: ScriptEngineMain) : Bas
                     sender.sendMessage("${ChatColor.GREEN}GraalJS Version: ${scriptEngine?.eval("Graal.versionJS")}")
                 }
                 else {
-                    sender.sendMessage("- ${ChatColor.GREEN}GraalJS Engine Version: v20.0.0")
+                    sender.sendMessage("- ${ChatColor.GREEN}GraalJS Engine Version: v20.1.0")
                 }
                 sender.sendMessage("-----------------------------------------------------")
             }
             else if(scriptEngineMain.scriptLanguage == "python") {
                 sender.sendMessage("- ${ChatColor.DARK_BLUE}ScriptableMC Python Engine: ${scriptEngineMain.pluginVersion}")
-                sender.sendMessage("- ${ChatColor.BLUE}GraalPython Version: v20.0.0")
+                sender.sendMessage("- ${ChatColor.BLUE}GraalPython Version: v20.1.0")
                 sender.sendMessage("-----------------------------------------------------")
 
             }

--- a/ScriptableMC-Engine-Core/src/main/kotlin/com/pixlfox/scriptablemc/core/ScriptablePluginContext.kt
+++ b/ScriptableMC-Engine-Core/src/main/kotlin/com/pixlfox/scriptablemc/core/ScriptablePluginContext.kt
@@ -4,6 +4,7 @@ import com.smc.version.Version
 import fr.minuskube.inv.InventoryManager
 import me.clip.placeholderapi.PlaceholderAPI
 import org.bukkit.Bukkit
+import org.bukkit.Material
 import org.bukkit.OfflinePlayer
 import org.bukkit.Server
 import org.bukkit.command.CommandMap
@@ -28,6 +29,7 @@ abstract class ScriptablePluginContext: Listener {
     abstract val pluginInstance: Value
     abstract val inventoryManager: InventoryManager
     abstract val pluginVersion: Version
+    open val pluginIcon: Material = Material.STONE
 
     var isEnabled: Boolean = false
         internal set

--- a/ScriptableMC-Engine-JS/Bundled/build.gradle.kts
+++ b/ScriptableMC-Engine-JS/Bundled/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation("org.graalvm.tools:profiler:20.1.0")
 
     implementation("com.github.jkcclemens:khttp:-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.16.1-R0.1-SNAPSHOT")
     implementation("co.aikar:acf-paper:0.5.0-SNAPSHOT")
     implementation("fr.minuskube.inv:smart-invs:1.2.7")
     compileOnly("me.clip:placeholderapi:2.10.4")

--- a/ScriptableMC-Engine-JS/Bundled/build.gradle.kts
+++ b/ScriptableMC-Engine-JS/Bundled/build.gradle.kts
@@ -21,12 +21,12 @@ dependencies {
     implementation(project(":ScriptableMC-Engine-JS"))
 
     // GraalVM SDK & GraalJS Engine
-    implementation("org.graalvm.sdk:graal-sdk:20.0.0")
-    implementation("org.graalvm.js:js:20.0.0")
-    implementation("org.graalvm.js:js-scriptengine:20.0.0")
-    implementation("org.graalvm.truffle:truffle-api:20.0.0")
-    implementation("org.graalvm.tools:chromeinspector:20.0.0")
-    implementation("org.graalvm.tools:profiler:20.0.0")
+    implementation("org.graalvm.sdk:graal-sdk:20.1.0")
+    implementation("org.graalvm.js:js:20.1.0")
+    implementation("org.graalvm.js:js-scriptengine:20.1.0")
+    implementation("org.graalvm.truffle:truffle-api:20.1.0")
+    implementation("org.graalvm.tools:chromeinspector:20.1.0")
+    implementation("org.graalvm.tools:profiler:20.1.0")
 
     implementation("com.github.jkcclemens:khttp:-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT")

--- a/ScriptableMC-Engine-JS/Bundled/build.gradle.kts
+++ b/ScriptableMC-Engine-JS/Bundled/build.gradle.kts
@@ -56,5 +56,6 @@ tasks.jar {
 tasks.shadowJar {
     archiveFileName.set("ScriptableMC-Engine-JS-Bundled.jar")
     relocate("co.aikar.commands", "com.pixlfox.scriptablemc.acf")
+    relocate("de.tr7zw.changeme.nbtapi", "com.smc.nbtapi")
     mergeServiceFiles()
 }

--- a/ScriptableMC-Engine-JS/build.gradle.kts
+++ b/ScriptableMC-Engine-JS/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("commons-io:commons-io:2.6")
+    implementation("de.tr7zw:item-nbt-api:2.2.0")
 
     testImplementation("junit", "junit", "4.12")
 }
@@ -53,5 +54,6 @@ tasks.jar {
 tasks.shadowJar {
     archiveFileName.set("ScriptableMC-Engine-JS.jar")
     relocate("co.aikar.commands", "com.pixlfox.scriptablemc.acf")
+    relocate("de.tr7zw.changeme.nbtapi", "com.smc.nbtapi")
     mergeServiceFiles()
 }

--- a/ScriptableMC-Engine-JS/build.gradle.kts
+++ b/ScriptableMC-Engine-JS/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     compileOnly("org.graalvm.truffle:truffle-api:20.1.0")
 
     implementation("com.github.jkcclemens:khttp:-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.16.1-R0.1-SNAPSHOT")
     implementation("co.aikar:acf-paper:0.5.0-SNAPSHOT")
     implementation("fr.minuskube.inv:smart-invs:1.2.7")
     compileOnly("me.clip:placeholderapi:2.10.4")

--- a/ScriptableMC-Engine-JS/build.gradle.kts
+++ b/ScriptableMC-Engine-JS/build.gradle.kts
@@ -22,8 +22,8 @@ dependencies {
 
 
     // GraalVM SDK & GraalJS Engine
-    compileOnly("org.graalvm.sdk:graal-sdk:20.0.0")
-    compileOnly("org.graalvm.truffle:truffle-api:20.0.0")
+    compileOnly("org.graalvm.sdk:graal-sdk:20.1.0")
+    compileOnly("org.graalvm.truffle:truffle-api:20.1.0")
 
     implementation("com.github.jkcclemens:khttp:-SNAPSHOT")
     compileOnly("org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT")

--- a/ScriptableMC-Engine-JS/src/main/kotlin/com/pixlfox/scriptablemc/core/JavaScriptPluginContext.kt
+++ b/ScriptableMC-Engine-JS/src/main/kotlin/com/pixlfox/scriptablemc/core/JavaScriptPluginContext.kt
@@ -2,12 +2,13 @@ package com.pixlfox.scriptablemc.core
 
 import com.smc.version.Version
 import fr.minuskube.inv.InventoryManager
+import org.bukkit.Material
 import org.bukkit.event.HandlerList
 import org.graalvm.polyglot.Value
 
 
 @Suppress("MemberVisibilityCanBePrivate", "unused")
-class JavaScriptPluginContext(override val engine: ScriptablePluginEngine, override val pluginName: String, override val pluginInstance: Value) : ScriptablePluginContext() {
+class JavaScriptPluginContext(override val engine: ScriptablePluginEngine, override val pluginName: String, override val pluginIcon: Material, override val pluginInstance: Value) : ScriptablePluginContext() {
     override val inventoryManager: InventoryManager
         get() = engine.inventoryManager
 
@@ -48,12 +49,12 @@ class JavaScriptPluginContext(override val engine: ScriptablePluginEngine, overr
     }
 
     companion object {
-        fun newInstance(pluginName: String, engine: ScriptablePluginEngine, pluginInstance: Value): ScriptablePluginContext {
+        fun newInstance(pluginName: String, pluginIcon: Material, engine: ScriptablePluginEngine, pluginInstance: Value): ScriptablePluginContext {
             if(engine.debugEnabled) {
                 engine.bootstrapPlugin.logger.info("[$pluginName] Creating new JavaScript plugin context.")
             }
 
-            return JavaScriptPluginContext(engine, pluginName, pluginInstance)
+            return JavaScriptPluginContext(engine, pluginName, pluginIcon, pluginInstance)
         }
     }
 }

--- a/ScriptableMC-Engine-JS/src/main/kotlin/com/pixlfox/scriptablemc/core/JavaScriptPluginEngine.kt
+++ b/ScriptableMC-Engine-JS/src/main/kotlin/com/pixlfox/scriptablemc/core/JavaScriptPluginEngine.kt
@@ -5,6 +5,7 @@ import com.pixlfox.scriptablemc.ScriptEngineMain
 import com.smc.exceptions.ScriptNotFoundException
 import com.pixlfox.scriptablemc.utils.UnzipUtility
 import fr.minuskube.inv.InventoryManager
+import org.bukkit.Material
 import org.graalvm.polyglot.*
 import java.io.File
 
@@ -105,7 +106,16 @@ class JavaScriptPluginEngine(override val bootstrapPlugin: ScriptEngineMain, ove
     override fun loadPlugin(scriptableClass: Value): ScriptablePluginContext {
         val pluginInstance = scriptableClass.newInstance()
         val pluginName = pluginInstance.getMember("pluginName").asString()
-        val pluginContext = JavaScriptPluginContext.newInstance(pluginName, this, pluginInstance)
+        var pluginIcon = Material.STONE
+        if(pluginInstance.hasMember("pluginIcon")) {
+            try {
+                pluginIcon = pluginInstance.getMember("pluginIcon").`as`(Material::class.java)
+            }
+            catch(e: Exception) {
+                e.printStackTrace()
+            }
+        }
+        val pluginContext = JavaScriptPluginContext.newInstance(pluginName, pluginIcon, this, pluginInstance)
         pluginInstance.putMember("context", pluginContext)
         scriptablePlugins.add(pluginContext)
         pluginContext.load()

--- a/ScriptableMC-Engine-JS/src/main/kotlin/com/pixlfox/scriptablemc/core/JavaScriptPluginEngine.kt
+++ b/ScriptableMC-Engine-JS/src/main/kotlin/com/pixlfox/scriptablemc/core/JavaScriptPluginEngine.kt
@@ -92,38 +92,6 @@ class JavaScriptPluginEngine(override val bootstrapPlugin: ScriptEngineMain, ove
         globalBindings = graalContext.getBindings(languageName)
     }
 
-    override fun loadMainScript(path: String) {
-        try {
-            val mainScriptFile = File(path)
-            if(!mainScriptFile.parentFile.exists()) {
-                mainScriptFile.parentFile.mkdirs()
-            }
-
-            if(mainScriptFile.exists()) {
-                val mainReturn = eval(
-                    Source.newBuilder(languageName, mainScriptFile)
-                        .name(mainScriptFile.name)
-                        .mimeType(config.scriptMimeType)
-                        .interactive(false)
-                        .build()
-                )
-
-                // Load all plugin types returned as an array
-                if(mainReturn.hasArrayElements()) {
-                    for (i in 0 until mainReturn.arraySize) {
-                        this.loadPlugin(mainReturn.getArrayElement(i))
-                    }
-                }
-            }
-            else {
-                throw ScriptNotFoundException(mainScriptFile)
-            }
-        }
-        catch(ex: Exception) {
-            startupErrors.add(ex)
-        }
-    }
-
     override fun start() {
         instance = this
         super.start()

--- a/ScriptableMC-Engine-JS/src/main/resources/plugin.yml
+++ b/ScriptableMC-Engine-JS/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ScriptableMC-Engine-JS
 description: 'Run JavaScript/TypeScript plugins for Bukkit/Spigot/Paper Minecraft 1.15'
-version: '1.2.1'
+version: '1.2.2'
 api-version: '1.13'
 author: AStorks
 main: com.pixlfox.scriptablemc.SMCJavaScriptEngineMain

--- a/ScriptableMC-Engine-JS/src/main/resources/plugin.yml
+++ b/ScriptableMC-Engine-JS/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ScriptableMC-Engine-JS
 description: 'Run JavaScript/TypeScript plugins for Bukkit/Spigot/Paper Minecraft 1.15'
-version: '1.2.2'
+version: '1.3.0'
 api-version: '1.13'
 author: AStorks
 main: com.pixlfox.scriptablemc.SMCJavaScriptEngineMain

--- a/ScriptableMC-Engine-PY/Bundled/build.gradle.kts
+++ b/ScriptableMC-Engine-PY/Bundled/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
 
 
     implementation("com.github.jkcclemens:khttp:-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.16.1-R0.1-SNAPSHOT")
     implementation("co.aikar:acf-paper:0.5.0-SNAPSHOT")
     implementation("fr.minuskube.inv:smart-invs:1.2.7")
     compileOnly("me.clip:placeholderapi:2.10.4")

--- a/ScriptableMC-Engine-PY/Bundled/build.gradle.kts
+++ b/ScriptableMC-Engine-PY/Bundled/build.gradle.kts
@@ -21,8 +21,8 @@ dependencies {
     implementation(project(":ScriptableMC-Engine-PY"))
 
     // GraalVM SDK & GraalPython Engine
-    implementation("org.graalvm.sdk:graal-sdk:20.0.0")
-    implementation("org.graalvm.truffle:truffle-api:20.0.0")
+    implementation("org.graalvm.sdk:graal-sdk:20.1.0")
+    implementation("org.graalvm.truffle:truffle-api:20.1.0")
     implementation(files("libraries/graalpython.jar"))
     implementation(files("libraries/sulong-api.jar"))
     implementation(files("libraries/sulong.jar"))

--- a/ScriptableMC-Engine-PY/Bundled/build.gradle.kts
+++ b/ScriptableMC-Engine-PY/Bundled/build.gradle.kts
@@ -56,5 +56,6 @@ tasks.jar {
 tasks.shadowJar {
     archiveFileName.set("ScriptableMC-Engine-PY-Bundled.jar")
     relocate("co.aikar.commands", "com.pixlfox.scriptablemc.acf")
+    relocate("de.tr7zw.changeme.nbtapi", "com.smc.nbtapi")
     mergeServiceFiles()
 }

--- a/ScriptableMC-Engine-PY/build.gradle.kts
+++ b/ScriptableMC-Engine-PY/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("commons-io:commons-io:2.6")
+    implementation("de.tr7zw:item-nbt-api:2.2.0")
 
     testImplementation("junit", "junit", "4.12")
 }
@@ -53,5 +54,6 @@ tasks.jar {
 tasks.shadowJar {
     archiveFileName.set("ScriptableMC-Engine-PY.jar")
     relocate("co.aikar.commands", "com.pixlfox.scriptablemc.acf")
+    relocate("de.tr7zw.changeme.nbtapi", "com.smc.nbtapi")
     mergeServiceFiles()
 }

--- a/ScriptableMC-Engine-PY/build.gradle.kts
+++ b/ScriptableMC-Engine-PY/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
 
 
     implementation("com.github.jkcclemens:khttp:-SNAPSHOT")
-    compileOnly("org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot-api:1.16.1-R0.1-SNAPSHOT")
     implementation("co.aikar:acf-paper:0.5.0-SNAPSHOT")
     implementation("fr.minuskube.inv:smart-invs:1.2.7")
     compileOnly("me.clip:placeholderapi:2.10.4")

--- a/ScriptableMC-Engine-PY/build.gradle.kts
+++ b/ScriptableMC-Engine-PY/build.gradle.kts
@@ -21,8 +21,8 @@ dependencies {
     implementation(project(":ScriptableMC-Engine-Core"))
 
     // GraalVM SDK & GraalPython Engine
-    compileOnly("org.graalvm.sdk:graal-sdk:20.0.0")
-    compileOnly("org.graalvm.truffle:truffle-api:20.0.0")
+    compileOnly("org.graalvm.sdk:graal-sdk:20.1.0")
+    compileOnly("org.graalvm.truffle:truffle-api:20.1.0")
 
 
     implementation("com.github.jkcclemens:khttp:-SNAPSHOT")

--- a/ScriptableMC-Engine-PY/src/main/kotlin/com/pixlfox/scriptablemc/core/PythonPluginEngine.kt
+++ b/ScriptableMC-Engine-PY/src/main/kotlin/com/pixlfox/scriptablemc/core/PythonPluginEngine.kt
@@ -2,7 +2,6 @@ package com.pixlfox.scriptablemc.core
 
 import com.pixlfox.scriptablemc.SMCPythonConfig
 import com.pixlfox.scriptablemc.ScriptEngineMain
-import com.smc.exceptions.ScriptNotFoundException
 import com.pixlfox.scriptablemc.utils.UnzipUtility
 import fr.minuskube.inv.InventoryManager
 import org.graalvm.polyglot.*
@@ -53,41 +52,6 @@ class PythonPluginEngine(override val bootstrapPlugin: ScriptEngineMain, overrid
         globalBindings = graalContext.getBindings(languageName)
     }
 
-    override fun loadMainScript(path: String) {
-        try {
-            val mainScriptFile = File(path)
-            if(!mainScriptFile.parentFile.exists()) {
-                mainScriptFile.parentFile.mkdirs()
-            }
-
-            if(mainScriptFile.exists()) {
-                val mainReturn = eval(
-                    Source.newBuilder(languageName, mainScriptFile)
-                        .name(mainScriptFile.name)
-                        .interactive(false)
-                        .build()
-                )
-
-                // Load all plugin types returned as an array
-                if(mainReturn.hasArrayElements()) {
-                    for (i in 0 until mainReturn.arraySize) {
-                        this.loadPlugin(mainReturn.getArrayElement(i))
-                    }
-
-                    // Enable all plugins if not already enabled
-                    if(!enabledAllPlugins) {
-                        enableAllPlugins()
-                    }
-                }
-            }
-            else {
-                throw ScriptNotFoundException(mainScriptFile)
-            }
-        }
-        catch(ex: Exception) {
-            startupErrors.add(ex)
-        }
-    }
 
     override fun start() {
         instance = this

--- a/ScriptableMC-Engine-PY/src/main/resources/plugin.yml
+++ b/ScriptableMC-Engine-PY/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ScriptableMC-Engine-PY
 description: 'Run Python plugins for Bukkit/Spigot/Paper Minecraft 1.15'
-version: '1.2.2'
+version: '1.3.0'
 api-version: '1.13'
 author: AStorks
 main: com.pixlfox.scriptablemc.SMCPythonEngineMain

--- a/ScriptableMC-Engine-PY/src/main/resources/plugin.yml
+++ b/ScriptableMC-Engine-PY/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ScriptableMC-Engine-PY
 description: 'Run Python plugins for Bukkit/Spigot/Paper Minecraft 1.15'
-version: '1.2.1'
+version: '1.2.2'
 api-version: '1.13'
 author: AStorks
 main: com.pixlfox.scriptablemc.SMCPythonEngineMain

--- a/ScriptableMC-Tools-TS/build.gradle.kts
+++ b/ScriptableMC-Tools-TS/build.gradle.kts
@@ -21,13 +21,14 @@ dependencies {
     implementation(project(":ScriptableMC-Engine-JS"))
 
     // GraalVM SDK & GraalJS Engine
-    implementation("org.graalvm.sdk:graal-sdk:20.0.0")
-    implementation("org.graalvm.js:js:20.0.0")
-    implementation("org.graalvm.js:js-scriptengine:20.0.0")
-    implementation("org.graalvm.truffle:truffle-api:20.0.0")
+    implementation("org.graalvm.sdk:graal-sdk:20.1.0")
+    implementation("org.graalvm.js:js:20.1.0")
+    implementation("org.graalvm.js:js-scriptengine:20.1.0")
+    implementation("org.graalvm.truffle:truffle-api:20.1.0")
 
     implementation("com.github.jkcclemens:khttp:-SNAPSHOT")
     implementation("org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT")
+    implementation("net.md-5:bungeecord-api:1.15-SNAPSHOT")
     implementation("co.aikar:acf-paper:0.5.0-SNAPSHOT")
     implementation("fr.minuskube.inv:smart-invs:1.2.7")
     compileOnly("me.clip:placeholderapi:2.10.4")

--- a/ScriptableMC-Tools-TS/build.gradle.kts
+++ b/ScriptableMC-Tools-TS/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation("com.beust:klaxon:5.2")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("commons-io:commons-io:2.6")
+    implementation("de.tr7zw:item-nbt-api:2.2.0")
 
     testImplementation("junit", "junit", "4.12")
 }

--- a/ScriptableMC-Tools-TS/build.gradle.kts
+++ b/ScriptableMC-Tools-TS/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     implementation("org.graalvm.truffle:truffle-api:20.1.0")
 
     implementation("com.github.jkcclemens:khttp:-SNAPSHOT")
-    implementation("org.spigotmc:spigot-api:1.15.2-R0.1-SNAPSHOT")
+    implementation("org.spigotmc:spigot-api:1.16.1-R0.1-SNAPSHOT")
     implementation("net.md-5:bungeecord-api:1.15-SNAPSHOT")
     implementation("co.aikar:acf-paper:0.5.0-SNAPSHOT")
     implementation("fr.minuskube.inv:smart-invs:1.2.7")

--- a/ScriptableMC-Tools-TS/src/main/kotlin/com/pixlfox/scriptablemc/TypescriptLibraryExporter.kt
+++ b/ScriptableMC-Tools-TS/src/main/kotlin/com/pixlfox/scriptablemc/TypescriptLibraryExporter.kt
@@ -51,6 +51,7 @@ class TypescriptLibraryExporter(args: Array<String> = arrayOf()) {
         name.equals("name", true) -> "_name"
         name.equals("<set-?>", true) -> "value"
         name.equals("in", true) -> "_in"
+        name.equals("with", true) -> "_with"
         else -> name
     }
 

--- a/ScriptableMC-Tools-TS/src/main/kotlin/com/pixlfox/scriptablemc/TypescriptLibraryExporter.kt
+++ b/ScriptableMC-Tools-TS/src/main/kotlin/com/pixlfox/scriptablemc/TypescriptLibraryExporter.kt
@@ -749,7 +749,7 @@ class TypescriptLibraryExporter(args: Array<String> = arrayOf()) {
         }
 
         for(_interface in _class.interfaces) {
-            if(_interface.name.startsWith("org.bukkit")) {
+            if(_interface.name.matches(allowedPackagesRegex)) {
                 interfaceNames.add(stripPackageName(_interface.name))
             }
         }
@@ -769,10 +769,10 @@ class TypescriptLibraryExporter(args: Array<String> = arrayOf()) {
 
     private fun getParameters(_method: Method): Array<String> {
         val parameterNames = mutableListOf<String>()
-        val paranames = paranamer.lookupParameterNames(_method, false)
+        val parameterNamesLookup = paranamer.lookupParameterNames(_method, false)
 
         for((index, _parameter) in _method.parameters.withIndex()) {
-            parameterNames.add("${safeName(paranames.getOrElse(index) { _parameter.name })}: ${safeClassName(javaClassToTypescript(_parameter.type))}")
+            parameterNames.add("${safeName(parameterNamesLookup.getOrElse(index) { _parameter.name })}: ${safeClassName(javaClassToTypescript(_parameter.type))}")
         }
 
         return parameterNames.toTypedArray()

--- a/ScriptableMC-Tools-TS/src/main/kotlin/com/pixlfox/scriptablemc/TypescriptLibraryExporter.kt
+++ b/ScriptableMC-Tools-TS/src/main/kotlin/com/pixlfox/scriptablemc/TypescriptLibraryExporter.kt
@@ -143,6 +143,17 @@ class TypescriptLibraryExporter(args: Array<String> = arrayOf()) {
             com.pixlfox.scriptablemc.core.ScriptablePluginEngine::class.java,
             ScriptEngineMain::class.java,
 
+            net.md_5.bungee.api.chat.BaseComponent::class.java,
+            net.md_5.bungee.api.chat.TextComponent::class.java,
+            net.md_5.bungee.api.chat.ComponentBuilder::class.java,
+            net.md_5.bungee.api.chat.ClickEvent::class.java,
+            net.md_5.bungee.api.chat.HoverEvent::class.java,
+            net.md_5.bungee.api.chat.KeybindComponent::class.java,
+            net.md_5.bungee.api.chat.ScoreComponent::class.java,
+            net.md_5.bungee.api.chat.SelectorComponent::class.java,
+            net.md_5.bungee.api.chat.TranslatableComponent::class.java,
+            net.md_5.bungee.api.chat.Keybinds::class.java,
+
             com.smc.utils.ItemBuilder::class.java,
             com.smc.utils.MysqlWrapper::class.java,
             com.smc.utils.Http::class.java,

--- a/ScriptableMC-Tools-TS/src/main/ts/JsPlugin.ts
+++ b/ScriptableMC-Tools-TS/src/main/ts/JsPlugin.ts
@@ -7,14 +7,21 @@ import PluginMessageListenerRegistration from "./org/bukkit/plugin/messaging/Plu
 import OfflinePlayer from "./org/bukkit/OfflinePlayer.js";
 import MysqlWrapper from "./com/smc/utils/MysqlWrapper.js";
 import File from "./java/io/File.js";
+import ScriptablePluginEngine from "./com/pixlfox/scriptablemc/core/ScriptablePluginEngine.js";
+import ScriptEngineConfig from "./com/pixlfox/scriptablemc/ScriptEngineConfig.js";
 
 declare type Type<T> = { new (...args: any[]): T; };
+declare const engine: ScriptablePluginEngine;
 
 export default class JsPlugin {
     public context: ScriptablePluginContext;
 
     get pluginName(): string {
         return this.constructor.name;
+    }
+
+    get engineConfig(): ScriptEngineConfig {
+        return engine.getConfig();
     }
 
     get server(): Server {
@@ -67,6 +74,10 @@ export default class JsPlugin {
 
     setPlaceholders(player: (Player | OfflinePlayer), placeholderText: string): string {
         return this.context.setPlaceholders(player, placeholderText);
+    }
+
+    getPluginInstance<T>(pluginName: string): T {
+        return engine.getPluginInstance(pluginName);
     }
 
     onLoad(): void { console.log("[" + this.pluginName + "] onLoad()"); }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,22 +52,22 @@ tasks.register("shadowJarAll") {
 
     dependsOn(":ScriptableMC-Engine-JS:shadowJar")
     dependsOn(":ScriptableMC-Engine-JS:Bundled:shadowJar")
-    dependsOn(":ScriptableMC-Engine-PY:shadowJar")
-    dependsOn(":ScriptableMC-Engine-PY:Bundled:shadowJar")
+//    dependsOn(":ScriptableMC-Engine-PY:shadowJar")
+//    dependsOn(":ScriptableMC-Engine-PY:Bundled:shadowJar")
 
     doFirst {
         if(!file("./build").exists()) file("./build").mkdirs()
         if(file("./build/ScriptableMC-Engine-JS.jar").exists()) file("./build/ScriptableMC-Engine-JS.jar").delete()
         if(file("./build/ScriptableMC-Engine-JS-Bundled.jar").exists()) file("./build/ScriptableMC-Engine-JS-Bundled.jar").delete()
-        if(file("./build/ScriptableMC-Engine-PY.jar").exists()) file("./build/ScriptableMC-Engine-PY.jar").delete()
-        if(file("./build/ScriptableMC-Engine-PY-Bundled.jar").exists()) file("./build/ScriptableMC-Engine-PY-Bundled.jar").delete()
+//        if(file("./build/ScriptableMC-Engine-PY.jar").exists()) file("./build/ScriptableMC-Engine-PY.jar").delete()
+//        if(file("./build/ScriptableMC-Engine-PY-Bundled.jar").exists()) file("./build/ScriptableMC-Engine-PY-Bundled.jar").delete()
     }
 
     doLast {
         file("./ScriptableMC-Engine-JS/build/libs/ScriptableMC-Engine-JS.jar").copyTo(file("./build/ScriptableMC-Engine-JS.jar"), overwrite = true)
         file("./ScriptableMC-Engine-JS/Bundled/build/libs/ScriptableMC-Engine-JS-Bundled.jar").copyTo(file("./build/ScriptableMC-Engine-JS-Bundled.jar"), overwrite = true)
-        file("./ScriptableMC-Engine-PY/build/libs/ScriptableMC-Engine-PY.jar").copyTo(file("./build/ScriptableMC-Engine-PY.jar"), overwrite = true)
-        file("./ScriptableMC-Engine-PY/Bundled/build/libs/ScriptableMC-Engine-PY-Bundled.jar").copyTo(file("./build/ScriptableMC-Engine-PY-Bundled.jar"), overwrite = true)
+//        file("./ScriptableMC-Engine-PY/build/libs/ScriptableMC-Engine-PY.jar").copyTo(file("./build/ScriptableMC-Engine-PY.jar"), overwrite = true)
+//        file("./ScriptableMC-Engine-PY/Bundled/build/libs/ScriptableMC-Engine-PY-Bundled.jar").copyTo(file("./build/ScriptableMC-Engine-PY-Bundled.jar"), overwrite = true)
     }
 
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = "com.pixlfox.scriptablemc"
-    version = "1.2.2"
+    version = "1.3.0"
 
     repositories {
         mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,10 @@ allprojects {
             name = "aikar-acf"
             url = uri("https://repo.aikar.co/content/groups/aikar/")
         }
+        maven {
+            name = "codemc-repo"
+            url = uri("https://repo.codemc.org/repository/maven-public/")
+        }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = "com.pixlfox.scriptablemc"
-    version = "1.2.1"
+    version = "1.2.2"
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
## What's New
#### Minecraft 1.16 support
> Now targeting minecraft 1.16.1, the plugin should work with any version 1.13-1.16

#### Typescript exporter now supports the spigot api
> - The TypeScript exporter now supports the spigot api allowing access to spigot features like the action bar api.
> 
> **TypeScript Example:**
> ```ts
> import ChatMessageType from '../lib/net/md_5/bungee/api/ChatMessageType.js';
> import ComponentBuilder from '../lib/net/md_5/bungee/api/chat/ComponentBuilder.js';
> import SpigotChatColor from '../lib/net/md_5/bungee/api/ChatColor.js';
> 
> ...
> 
> let componentBuilder = new ComponentBuilder("Hello World!!").color(SpigotChatColor.AQUA);
> player.spigot().sendMessage(ChatMessageType.ACTION_BAR, componentBuilder.getParts());
> 
> ...
> ```

#### JavaScript Engine
> - Updated the JavaScript engine to the latest GeaalJS v20.1

#### Python Engine
> - Currently disabled the python engine, will be re-enabled later on.